### PR TITLE
Rename ./run into ./sabre

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -33,8 +33,9 @@ target_include_directories(loader PUBLIC ./includes)
 target_link_libraries(loader dl)
 
 # Build loader
-add_executable(run main.s)
-target_link_libraries(run loader libsrc)
+add_executable(sabre main.s)
+set_target_properties(sabre PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+target_link_libraries(sabre loader libsrc)
 
 # Build tools
 add_executable(process-vdso tools/process-vdso.c)


### PR DESCRIPTION
Closes #6 

Also move the executable to the top of the build tree.