### PR TITLE
Stop ignoring write return values from SIGSEGV handler

### DIFF
--- a/plugins/sc-fuzzer/sc-fuzzer.c
+++ b/plugins/sc-fuzzer/sc-fuzzer.c
@@ -409,7 +409,8 @@ void_void_fn handle_vdso(long sc_no, void_void_fn actual_fn) {
 }
 
 static void segv_handler(int sig) {
-  write(STDERR_FILENO, "Caught SIGSEGV at:\n", 19);
+  ssize_t bytes = write(STDERR_FILENO, "Caught SIGSEGV at:\n", 19);
+  if (bytes != 19) goto error;
 
   // This does not have the expected behaviour, but leaving it here for now, in
   // case there is a solution
@@ -427,6 +428,7 @@ static void segv_handler(int sig) {
   sigemptyset(&sa.sa_mask);
   sa.sa_flags = 0;
   sigaction(sig, &sa, NULL);
+error:
   raise(sig);
 }
 


### PR DESCRIPTION
This is needed to satisfy the version of gcc that runs in our group's CI as per [this](https://github.com/srg-imperial/varan/pull/228#pullrequestreview-197021861).