### PR TITLE
Drop vsyscall support

### DIFF
--- a/loader/maps.c
+++ b/loader/maps.c
@@ -86,7 +86,6 @@ out:
 static void maps_init(struct maps *maps, int fd) {
   maps->fd = fd;
   maps->lib_vdso = NULL;
-  maps->lib_vsyscall = NULL;
 
   for (int i = 0; i < LIBS_HASHTABLE_SIZE; i++)
     INIT_HLIST_HEAD(&maps->libraries[i]);
@@ -343,17 +342,6 @@ struct maps* maps_read(void) {
           library_init(lib, pathname, maps);
           lib->vdso = true;
           maps->lib_vdso = lib;
-          rb_insert_region(lib, offset, &reg->rb_region);
-        } else if (strncmp(pathname, "[vsyscall]", 10) == 0) {
-          _nx_debug_printf("vsyscall library found\n");
-
-          assert(maps->lib_vsyscall == NULL); // We currently support only 1 memory region
-          assert(offset == 0);
-          reg->type = REGION_VSYSCALL;
-
-          struct library* lib = malloc(sizeof(*lib));
-          library_init(lib, pathname, maps);
-          maps->lib_vsyscall = lib;
           rb_insert_region(lib, offset, &reg->rb_region);
         } else if (pathname[0] == '/') {
           reg->type = REGION_LIBRARY;

--- a/loader/maps.h
+++ b/loader/maps.h
@@ -27,7 +27,6 @@ enum region_type {
   REGION_STACK = 0x8,
   REGION_BSS = 0x10,
   REGION_VDSO = 0x20,
-  REGION_VSYSCALL = 0x40,
   REGION_ALL = 0x7F,
 };
 
@@ -40,7 +39,6 @@ struct maps {
   int fd;
 
   struct library* lib_vdso;
-  struct library* lib_vsyscall;
 
   // This is a hash table: <library_hashfn(lib_pathname), struct library>
   struct hlist_head libraries[LIBS_HASHTABLE_SIZE];

--- a/loader/rewriter.h
+++ b/loader/rewriter.h
@@ -60,7 +60,6 @@ struct library {
   bool valid;
   bool vdso; // TODO(andronat): remove this field
   char *asr_offset;
-  int vsys_offset; // TODO(andronat): remove this field
   Elf_Ehdr ehdr;
   struct rb_root rb_region;
   struct hlist_head *section_hash;
@@ -71,7 +70,6 @@ struct library {
   struct hlist_node library_hash;
 };
 
-extern char *__kernel_vsyscall __internal;
 extern char *__kernel_sigreturn __internal;
 extern char *__kernel_rt_sigreturn __internal;
 


### PR DESCRIPTION
vsyscall has been deprecated in favour of vDSO for years. Dynamic binaries are not affected, since glibc has switched to vDSO a long time ago. Only very old static binaries are.
In addition, vsyscall support in SaBRe has been shown to cause segfaults on some kernels.