### PR TITLE
Intercept SIGILL

### DIFF
--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -9,7 +9,6 @@ set(SRCS
   handle_syscall.S
   handle_syscall_loader.s
   handle_vdso.s
-  handle_rdtsc.s
   ld_sc_handler.c
   rewriter.c
   loader.c
@@ -25,6 +24,7 @@ endif(DEBUG)
 
 if (RDTSC)
   add_definitions(-D__NX_INTERCEPT_RDTSC)
+  set(SRCS ${SRCS} handle_rdtsc.s)
 endif(RDTSC)
 
 # Build library


### PR DESCRIPTION
When SaBRe is unable to accommodate a jump to a trampoline, it instead replaces the `SYSCALL` or `RDTSC` instruction with a `UD` instruction that causes a SIGILL.
This patch installs a dedicated signal handler that passes control to the plugin accordingly.