### PR TITLE
CFI followups

### DIFF
--- a/loader/handle_syscall.S
+++ b/loader/handle_syscall.S
@@ -78,9 +78,8 @@ handle_syscall:
   and $0xfffffffffffffff0, %rsp
 
   # Adjust the arguments
-  pushq %rsp         # reserve space for wrapper_sp
+  pushq %rbp         # wrapper_sp
   pushq %r9          # arg6
-  movq %rsp, 8(%rsp) # wrapper_sp
   movq %r8, %r9      # arg5
   movq %r10, %r8     # arg4
   movq %rdx, %rcx    # arg3

--- a/loader/handle_syscall.h
+++ b/loader/handle_syscall.h
@@ -5,10 +5,7 @@
 
 // Stack frame built by handle_syscall and in the patching code in library.c
 struct syscall_stackframe {
-  // handle_syscall
-  void *r9;
-  void *wrapper_sp;
-  void *rbp;
+  void *rbp_stackalign;
   void *r15;
   void *r14;
   void *r13;
@@ -21,6 +18,7 @@ struct syscall_stackframe {
   void *rdx;
   void *rcx;
   void *rbx;
+  void *rbp_prologue;
   // trampoline
   void *fake_ret;
   void *ret;


### PR DESCRIPTION
* Move prologue after `sigreturn` handling
* Adapt `syscall_stackframe` to dynamic stack alignment