### PR TITLE
Segregate SaBRe and client malloc arenas with mallopt

### DIFF
--- a/loader/maps.c
+++ b/loader/maps.c
@@ -30,7 +30,7 @@
 #include "macros.h"
 
 #define MAX_BUF_SIZE PATH_MAX + 1024
-#define MAX_INITIAL_MAPPINGS 31
+#define MAX_INITIAL_MAPPINGS 41
 
 static long initial_mappings[MAX_INITIAL_MAPPINGS];
 static int initial_mapping_cnt = 0;


### PR DESCRIPTION
There 2 mallocs in memory because SaBRe loads 2 libcs (one for SaBRe) and one for the client (which is intercepted). These two mallocs will overlap their arenas as malloc uses brk(NULL) to initialize its arena, and this brk(NULL) will always return the same pointer. To avoid this we force SaBRe's malloc to completely skip the arena initialization and keep objects into separate mmap() pages. 

This of course comes with a small performance decrease, and the potential to OOM if we allocate too many items.
