### PR TITLE
Don't redefine __USE_GNU

### DIFF
--- a/plugins/sbr-trace/strace.c
+++ b/plugins/sbr-trace/strace.c
@@ -12,7 +12,9 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+#ifndef __USE_GNU
 #define __USE_GNU
+#endif
 #include <fcntl.h>
 #include <sys/mman.h>
 #undef __USE_GNU


### PR DESCRIPTION
This file may fail to compile if __USE_GNU is already defined on the
command line.