### PR TITLE
Fix compilation error in loader/ld_sc_handler.c

### DIFF
--- a/loader/ld_sc_handler.c
+++ b/loader/ld_sc_handler.c
@@ -399,7 +399,7 @@ long ld_sc_handler(long sc_no, long arg1, long arg2, long arg3, long arg4,
 
       _nx_debug_printf("readlink: enter loader syscall (\"%s\", %p -> "
                        "\"%.*s\", %zu) -> %zu\n",
-                       pathname, buf, len, buf, bufsize, len);
+                       pathname, buf, (int)len, buf, bufsize, len);
 
       return len;
     } else {


### PR DESCRIPTION
Enabling debug logging makes the compiler fail
```
.../SaBRe/loader/ld_sc_handler.c:400:24: error: field precision specifier ‘.*’ expects argument of type ‘int’, but argument 5 has type ‘size_t’ {aka ‘long unsigned int’} [-Werror=format=]
  400 |       _nx_debug_printf("readlink: enter loader syscall (\"%s\", %p -> "
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  401 |                        "\"%.*s\", %zu) -> %zu\n",
  402 |                        pathname, buf, len, buf, bufsize, len);
      |                                       ~~~
      |                                       |
      |                                       size_t {aka long unsigned int}
.../SaBRe/includes/macros.h:25:16: note: in definition of macro ‘_nx_debug_printf’
   25 |     dprintf(2, fmt, ##args);                                                   \
      |                ^~~
cc1: all warnings being treated as errors
```
Casting len to `int` fixes this issue

Note: I am using `gcc (GCC) 12.1.0` as my compiler