### PR TITLE
Mimic GDB external debug info search procedure

### DIFF
--- a/includes/loader/debuginfo.h
+++ b/includes/loader/debuginfo.h
@@ -1,0 +1,14 @@
+/*  Copyright © 2019 Software Reliability Group, Imperial College London
+ *
+ *  This file is part of SaBRe.
+ *
+ *  SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef DEBUGINFO_H
+#define DEBUGINFO_H
+
+// Lookup external debug info file for a given executable/library
+char *debuginfo_lookup_external(const char *absolute_path);
+
+#endif

--- a/includes/loader/elf_loading.h
+++ b/includes/loader/elf_loading.h
@@ -15,6 +15,10 @@
 
 int elfld_getehdr(int, ElfW(Ehdr) *);
 GElf_Sym find_elf_symbol(const char *, const char *, bool *);
+bool read_elf_note(const char *path, Elf64_Word note_type, const char *owner,
+                   void *notebuf, size_t *notesz);
+bool read_elf_section(const char *path, const char *section_name, void *scbuf,
+                      size_t *scsz);
 ElfW(Addr) addr_of_elf_symbol(const char *, const char *, bool *);
 ElfW(Addr) elfld_load_elf(int fd, ElfW(Ehdr) const *ehdr, size_t pagesize,
                           ElfW(Addr) * out_phdr, ElfW(Addr) * out_phnum,

--- a/includes/stringutil.h
+++ b/includes/stringutil.h
@@ -1,0 +1,34 @@
+/*  Copyright © 2019 Software Reliability Group, Imperial College London
+ *
+ *  This file is part of SaBRe.
+ *
+ *  SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef STRINGUTIL_H
+#define STRINGUTIL_H
+
+#include <stdlib.h>
+#include <string.h>
+
+static inline char *copy_string(const char *str) {
+  size_t len = strlen(str);
+  char *result = malloc(len);
+  if (result == NULL) {
+    return NULL;
+  }
+  memcpy(result, str, len);
+  result[len] = '\0';
+  return result;
+}
+
+static inline void hexdump(size_t bytes, const void *in, char *out) {
+  const unsigned char *cin = in;
+  for (size_t i = 0; i < bytes; ++i) {
+    static const char digits[] = "0123456789abcdef";
+    out[2 * i] = digits[cin[i] / 16];
+    out[2 * i + 1] = digits[cin[i] % 16];
+  }
+}
+
+#endif

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -14,7 +14,8 @@ sabre_add_component(
   loader.c
   maps.c
   premain.c
-  rewriter.c)
+  rewriter.c
+  debuginfo.c)
 
 target_link_libraries(loader ${CMAKE_DL_LIBS} backend elf plugin_api)
 

--- a/loader/debuginfo.c
+++ b/loader/debuginfo.c
@@ -1,0 +1,217 @@
+/*  Copyright © 2019 Software Reliability Group, Imperial College London
+ *
+ *  This file is part of SaBRe.
+ *
+ *  SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+// See https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html for the outline of the lookup procedure
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE 1
+#endif
+
+#include "elf_loading.h"
+#include "kernel.h"
+#include "macros.h"
+#include "stringutil.h"
+
+#include <assert.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <libgen.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+// Copied from https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
+static unsigned long gnu_debuglink_crc32(unsigned long crc, unsigned char *buf,
+                                         size_t len) {
+  static const unsigned long crc32_table[256] = {
+      0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
+      0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
+      0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91, 0x1db71064, 0x6ab020f2,
+      0xf3b97148, 0x84be41de, 0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
+      0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec, 0x14015c4f, 0x63066cd9,
+      0xfa0f3d63, 0x8d080df5, 0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
+      0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b, 0x35b5a8fa, 0x42b2986c,
+      0xdbbbc9d6, 0xacbcf940, 0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
+      0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423,
+      0xcfba9599, 0xb8bda50f, 0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
+      0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d, 0x76dc4190, 0x01db7106,
+      0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
+      0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818, 0x7f6a0dbb, 0x086d3d2d,
+      0x91646c97, 0xe6635c01, 0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
+      0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457, 0x65b0d9c6, 0x12b7e950,
+      0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
+      0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2, 0x4adfa541, 0x3dd895d7,
+      0xa4d1c46d, 0xd3d6f4fb, 0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
+      0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9, 0x5005713c, 0x270241aa,
+      0xbe0b1010, 0xc90c2086, 0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
+      0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17, 0x2eb40d81,
+      0xb7bd5c3b, 0xc0ba6cad, 0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
+      0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683, 0xe3630b12, 0x94643b84,
+      0x0d6d6a3e, 0x7a6a5aa8, 0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
+      0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb,
+      0x196c3671, 0x6e6b06e7, 0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
+      0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5, 0xd6d6a3e8, 0xa1d1937e,
+      0x38d8c2c4, 0x4fdff252, 0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
+      0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60, 0xdf60efc3, 0xa867df55,
+      0x316e8eef, 0x4669be79, 0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
+      0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f, 0xc5ba3bbe, 0xb2bd0b28,
+      0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
+      0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a, 0x9c0906a9, 0xeb0e363f,
+      0x72076785, 0x05005713, 0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
+      0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21, 0x86d3d2d4, 0xf1d4e242,
+      0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
+      0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c, 0x8f659eff, 0xf862ae69,
+      0x616bffd3, 0x166ccf45, 0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
+      0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db, 0xaed16a4a, 0xd9d65adc,
+      0x40df0b66, 0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
+      0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605, 0xcdd70693,
+      0x54de5729, 0x23d967bf, 0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
+      0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d};
+  unsigned char *end;
+
+  crc = ~crc & 0xffffffff;
+  for (end = buf + len; buf < end; ++buf)
+    crc = crc32_table[(crc ^ *buf) & 0xff] ^ (crc >> 8);
+  return ~crc & 0xffffffff;
+}
+
+// Verify debuginfo file
+static bool debuginfo_verify(const char *path, unsigned long *crc32_opt) {
+  if (access(path, R_OK)) {
+    return false;
+  }
+  // Optionally check that crc32 matches
+  if (crc32_opt == NULL) {
+    return true;
+  }
+  unsigned long crc32_expected = *crc32_opt;
+  unsigned long crc32_actual = 0;
+  unsigned char buf[BUFSIZ];
+  int fd = open(path, O_RDONLY);
+  if (fd < 0) {
+    return false;
+  }
+  ssize_t len;
+  while ((len = read(fd, buf, BUFSIZ)) > 0) {
+    crc32_actual = gnu_debuglink_crc32(crc32_actual, buf, (size_t)len);
+  }
+  close(fd);
+  _nx_debug_printf("crc32 check (expected %lu, got %lu)\n", crc32_expected,
+                   crc32_actual);
+  return crc32_actual == crc32_expected;
+}
+
+// .build-id length.
+#define NT_GNU_BUILD_ID_LENGTH 0x14
+
+// We assume that GLOBAL_DEBUG_DIR is set to /usr/lib/debug
+#define GLOBAL_DEBUG_DIR "/usr/lib/debug"
+
+// Try to find debug info using build ID. Returns path to the elf file with debug info
+static char *debuginfo_lookup_with_build_id(const char *path) {
+  // Query raw build ID
+  unsigned char build_id[NT_GNU_BUILD_ID_LENGTH];
+  size_t build_id_len = NT_GNU_BUILD_ID_LENGTH;
+  if (!read_elf_note(path, NT_GNU_BUILD_ID, "GNU", build_id, &build_id_len)) {
+    assert(false && "Failed to read GNU build id");
+  }
+  // Convert to hex to use in filesystem paths
+  char build_id_hex[2 * NT_GNU_BUILD_ID_LENGTH + 1];
+  hexdump(build_id_len, build_id, build_id_hex);
+  build_id_hex[2 * build_id_len] = '\0';
+  _nx_debug_printf("build id of %s is %s\n", path, build_id_hex);
+
+  // build_id is split into two components to speed up lookups: first two hex characters and the rest
+  char build_id_component1[3] = {'\0'};
+  memcpy(build_id_component1, build_id_hex, 2);
+  const char *build_id_component2 = build_id_hex + 2;
+
+  char debug_info_path[PATH_MAX];
+  // Try global_debug_dir/.build-id/build_id_component1/build_id_component2.debug
+  if (snprintf(debug_info_path, PATH_MAX, "%s/.build-id/%s/%s.debug",
+               GLOBAL_DEBUG_DIR, build_id_component1,
+               build_id_component2) < PATH_MAX) {
+    if (debuginfo_verify(debug_info_path, NULL)) {
+      _nx_debug_printf("debug info file: %s\n", debug_info_path);
+      return copy_string(debug_info_path);
+    }
+  }
+
+  return NULL;
+}
+
+// Try to find debug info file using .gnu_debuglink section
+// TODO: validate debug info checksums
+static char *debuginfo_lookup_with_debuglink(const char *path) {
+  char gnu_debuglink[PATH_MAX];
+  size_t gnu_debuglink_section_len = sizeof(gnu_debuglink);
+  if (!read_elf_section(path, ".gnu_debuglink", gnu_debuglink,
+                        &gnu_debuglink_section_len)) {
+    return NULL;
+  }
+  // .gnu_debuglink section has
+  // (1) debuginfo path component
+  // (2) nul byte
+  // (3) padding to the four byte-boundary
+  // (4) crc32 of the debuginfo file
+  size_t gnu_debuglink_len = strnlen(gnu_debuglink, gnu_debuglink_section_len);
+  size_t crc32_pos = roundup(gnu_debuglink_len + 1, 4);
+  assert(crc32_pos + 4 <= gnu_debuglink_section_len);
+  unsigned long crc32 = *(uint32_t *)(gnu_debuglink + crc32_pos);
+
+  _nx_debug_printf(".gnu_debuglink for %s points to %s\n", path, gnu_debuglink);
+
+  size_t path_len = strlen(path);
+  assert(path_len < PATH_MAX);
+  char dir_name_buf[PATH_MAX];
+  memcpy(dir_name_buf, path, path_len);
+  char *dir_name = dirname(dir_name_buf);
+
+  char debug_info_path[PATH_MAX];
+
+  // 1. Try ld_dir_name/debuglink
+  if (snprintf(debug_info_path, PATH_MAX, "%s/%s", dir_name, gnu_debuglink) <
+      PATH_MAX) {
+    if (debuginfo_verify(debug_info_path, &crc32)) {
+      _nx_debug_printf("debug info file: %s\n", debug_info_path);
+      return copy_string(debug_info_path);
+    }
+  }
+
+  // 2. Try ld_dir_name/.debug/debuglink
+  if (snprintf(debug_info_path, PATH_MAX, "%s/.debug/%s", dir_name,
+               gnu_debuglink) < PATH_MAX) {
+    if (debuginfo_verify(debug_info_path, &crc32)) {
+      _nx_debug_printf("debug info file: %s\n", debug_info_path);
+      return copy_string(debug_info_path);
+    }
+  }
+
+  // 3. Try global_debug_dir/ld_dir_name/debuglink
+  if (snprintf(debug_info_path, PATH_MAX, "%s/%s/%s", GLOBAL_DEBUG_DIR,
+               dir_name, gnu_debuglink) < PATH_MAX) {
+    if (debuginfo_verify(debug_info_path, &crc32)) {
+      _nx_debug_printf("debug info file: %s\n", debug_info_path);
+      return copy_string(debug_info_path);
+    }
+  }
+
+  return NULL;
+}
+
+// Lookup external debug info file for a given executable/library
+char *debuginfo_lookup_external(const char *absolute_path) {
+  // Try debuglink method
+  char *result = debuginfo_lookup_with_debuglink(absolute_path);
+  if (result != NULL) {
+    return result;
+  }
+  // Try build ID method
+  return debuginfo_lookup_with_build_id(absolute_path);
+}


### PR DESCRIPTION
Fixes #86

SaBRe can now be optionally compiled to use `<elfutils/debuginfod.h>` library. This allows SaBRe to download debug symbols for `ld.so` if SaBRe can't find these symbols otherwise. In particular, this makes `SaBRe` work on my Arch Linux system

```
notiurii@enterprise ~/S/build (debuginfod)> ./sabre plugins/sbr-trace/libsbr-trace.so -- /bin/ls
prctl(0X017, 0X020, 0X0, 0X07F62AEC40C08, 0X05605F297C658) = 0X01
prctl(0X017, 0X030, 0X0, 0X07F62AEC40C08, 0X05605F297C658) = -22(error)
prctl(0X017, 0X028, 0X0, 0X07F62AEC40C08, 0X05605F297C658) = 0X01
prctl(0X017, 0X02C, 0X0, 0X07F62AEC40C08, 0X05605F297C658) = -22(error)
prctl(0X017, 0X02A, 0X0, 0X07F62AEC40C08, 0X05605F297C658) = -22(error)
prctl(0X017, 0X029, 0X0, 0X07F62AEC40C08, 0X05605F297C658) = -22(error)
getrandom(0X07F62AEC04418, 0X08, 0X01) = 0X08
brk(0X0) = 0X05605F2DF4000
brk(0X05605F2E15000) = 0X05605F2E15000
openat("/usr/lib/locale/locale-archive", O_RDONLY|O_CLOEXEC) = 0X03
newfstatat(0X03, 0X07F62AEBBB073, 0X07F62AEBFEAC0, 0X01000) = 0X0
mmap(0X0, 0X02E85E0, PROT_READ, MAP_PRIVATE, 3, 0X0) = 0X07F62ACA00000
close(0X03) = 0X0
ioctl(0X01, 0X05401, 0X07FFE8EAF0A60) = 0X0
ioctl(0X01, 0X05413, 0X07FFE8EAF0B70) = 0X0
openat(".", O_RDONLY|O_CLOEXEC|O_DIRECTORY|O_NONBLOCK|O_TMPFILE00) = 0X03
newfstatat(0X03, 0X07F62AEBBB073, 0X07FFE8EAF0580, 0X01000) = 0X0
getdents64(0X03, 0X05605F2DFA720, 0X08000) = 0X01E8
getdents64(0X03, 0X05605F2DFA720, 0X08000) = 0X0
close(0X03) = 0X0
newfstatat(0X01, 0X07F62AEBBB073, 0X07FFE8EAEE580, 0X01000) = 0X0
arch  CMakeCache.txt  CMakeFiles  cmake_install.cmake  compile_commands.json  loader  log.txt  Makefile  plugin_api  plugins  sabre  tests  tools
write(1, "arch  CMakeCache.txt  CMakeFiles  cmake_install.cmake  compile_commands.json  loader  log.txt  Makefile  plugin_api  plugins  sabre  tests  tools\n", 0X092) = 0X092
close(0X01) = 0X0
close(0X02) = 0X0
notiurii@enterprise ~/S/build (debuginfod)>
```

To my knowledge, `debuginfod` is not commonly installed on Linux distributions. As such, I made `debuginfod` an optional dependency, which is disabled by default. Support for `debuginfod` can be enabled by passing `-DUSE_DEBUGINFO=ON` to make.

EDIT: now it can search in other places as well, mimicking logic from https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html