### PR TITLE
Use xmm0 to pass context to post_clone_hook

### DIFF
--- a/includes/plugins/real_syscall.h
+++ b/includes/plugins/real_syscall.h
@@ -36,10 +36,10 @@ long real_syscall(long sc_no, long arg1, long arg2, long arg3, long arg4,
                   long arg5, long arg6);
 
 long clone_syscall(unsigned long flags, void *child_stack, int *ptid, int *ctid,
-                   unsigned long newtls, void *ret_addr);
+                   unsigned long newtls, void *ret_addr, void *ctx);
 
 long clone3_syscall(long arg1, long arg2, long arg3, int not_used, long arg5,
-                    void *ret_addr);
+                    void *ret_addr, void *ctx);
 
 long vfork_syscall();
 long vfork_return_from_child(void *wrapper_sp);

--- a/loader/ld_sc_handler.c
+++ b/loader/ld_sc_handler.c
@@ -539,11 +539,11 @@ long runtime_syscall_router(long sc_no, long arg1, long arg2, long arg3,
     if (sc_no == SYS_clone && arg2 != 0) { // clone
       void *ret_addr = get_syscall_return_address(wrapper_sp);
       return clone_syscall(arg1, (void *)arg2, (void *)arg3, (void *)arg4, arg5,
-                           ret_addr);
+                           ret_addr, NULL);
     } else if (sc_no == SYS_clone3 &&
                ((struct clone_args *)arg1)->stack != 0) { // clone3
       void *ret_addr = get_syscall_return_address(wrapper_sp);
-      return clone3_syscall(arg1, arg2, arg3, 0, arg5, ret_addr);
+      return clone3_syscall(arg1, arg2, arg3, 0, arg5, ret_addr, NULL);
     }
     assert(sc_no != SYS_execve);
     assert(sc_no != SYS_vfork);
@@ -565,4 +565,7 @@ long runtime_syscall_router(long sc_no, long arg1, long arg2, long arg3,
   return rc;
 }
 
-void post_clone_hook() { return; }
+void post_clone_hook(void *ctx) {
+  (void)ctx;
+  return;
+}

--- a/plugin_api/arch/x86_64/clone3_syscall.s
+++ b/plugin_api/arch/x86_64/clone3_syscall.s
@@ -17,11 +17,19 @@
 #              not_used,      # - %rcx - is clobbered by syscall so we don't use it.
 #              long arg4,     # %r8  - void *arg
 #              void *ret_addr # %r9
+#              void *ctx      # +8(%rsp)
 #             );
 
 clone3_syscall:
   pushq %rbp
   movq %rsp, %rbp
+
+  # Save xmm0
+  subq $16, %rsp
+  movdqu %xmm0, (%rsp)
+
+  # Copy argument into xmm0
+  movq 16(%rbp), %xmm0
 
   # Call clone3
   movq $435, %rax
@@ -41,8 +49,14 @@ clone3_syscall:
   pushq %r8
   pushq %r9
 
+  # Call post_clone_hook with xmm0 as first argument
+  movq %xmm0, %rdi
   call *post_clone_hook@GOTPCREL(%rip)
+
   call *exit_plugin@GOTPCREL(%rip)
+
+  # Set xmm0 to NaN to catch xmm0 corruptions
+  pcmpeqd %xmm0, %xmm0
 
   popq %r9
   popq %r8
@@ -66,6 +80,11 @@ clone3_syscall:
 
 1:
   # Parent
+  
+  # Restore xmm0 value
+  movdqu (%rsp), %xmm0
+  addq $16, %rsp
+
   popq %rbp
   ret
 

--- a/plugin_api/arch/x86_64/clone_syscall.s
+++ b/plugin_api/arch/x86_64/clone_syscall.s
@@ -16,11 +16,19 @@
 #             int *ctid,            # %rcx
 #             unsigned long newtls, # %r8
 #             void* ret_addr        # %r9
+#             void* ctx             # +8(%rsp)
 #            );
 
 clone_syscall:
   pushq %rbp
   movq %rsp, %rbp
+
+  # Save xmm0
+  subq $16, %rsp
+  movdqu %xmm0, (%rsp)
+
+  # Copy argument into xmm0
+  movq 16(%rbp), %xmm0
 
   # Adjust the arguments
   movq $56, %rax
@@ -42,8 +50,14 @@ clone_syscall:
   pushq %r8
   pushq %r9
 
+  # Call post_clone_hook with xmm0 as first argument
+  movq %xmm0, %rdi
   call *post_clone_hook@GOTPCREL(%rip)
+
   call *exit_plugin@GOTPCREL(%rip)
+
+  # Set xmm0 to NaN to catch xmm0 corruptions
+  pcmpeqd %xmm0, %xmm0
 
   popq %r9
   popq %r8
@@ -60,6 +74,11 @@ clone_syscall:
 
 1:
   # Parent
+  
+  # Restore xmm0
+  movdqu (%rsp), %xmm0
+  addq $16, %rsp
+
   popq %rbp
   ret
 

--- a/plugin_api/recursion_protector.c
+++ b/plugin_api/recursion_protector.c
@@ -52,4 +52,7 @@ void vdso_are_ready() { vdso_ready = true; }
 
 bool is_vdso_ready() { return vdso_ready; }
 
-__attribute__((weak)) void post_clone_hook() { return; }
+__attribute__((weak)) void post_clone_hook(void *ctx) {
+  (void)ctx; // unused
+  return;
+}

--- a/plugins/sbr-id/identity.c
+++ b/plugins/sbr-id/identity.c
@@ -49,11 +49,11 @@ long handle_syscall(long sc_no, long arg1, long arg2, long arg3, long arg4,
   if (sc_no == SYS_clone && arg2 != 0) { // clone
     void *ret_addr = get_syscall_return_address(wrapper_sp);
     return clone_syscall(arg1, (void *)arg2, (void *)arg3, (void *)arg4, arg5,
-                         ret_addr);
+                         ret_addr, NULL);
   } else if (sc_no == SYS_clone3 &&
              ((struct clone_args *)arg1)->stack != 0) { // clone3
     void *ret_addr = get_syscall_return_address(wrapper_sp);
-    return clone3_syscall(arg1, arg2, arg3, 0, arg5, ret_addr);
+    return clone3_syscall(arg1, arg2, arg3, 0, arg5, ret_addr, NULL);
   } else if (sc_no == SYS_execve) {
     if (access((char *)arg1, F_OK) != 0) {
       // TODO: Double check this is the correct way to return errors.
@@ -184,7 +184,10 @@ long handle_rdtsc() {
 }
 #endif // __NX_INTERCEPT_RDTSC
 
-void post_clone_hook() { return; }
+void post_clone_hook(void *ctx) {
+  assert(ctx == NULL);
+  return;
+}
 
 void sbr_init(int *argc, char **argv[], sbr_icept_reg_fn fn_icept_reg,
               sbr_icept_vdso_callback_fn *vdso_callback,

--- a/plugins/sbr-trace/strace.c
+++ b/plugins/sbr-trace/strace.c
@@ -582,11 +582,11 @@ long handle_syscall_real(long sc_no, long arg1, long arg2, long arg3, long arg4,
       if (sc_no == SYS_clone && arg2 != 0) { // clone
         void *ret_addr = get_syscall_return_address(wrapper_sp);
         syscall_rtn = clone_syscall(arg1, (void *)arg2, (void *)arg3,
-                                    (void *)arg4, arg5, ret_addr);
+                                    (void *)arg4, arg5, ret_addr, NULL);
       } else if (sc_no == SYS_clone3 &&
                  ((struct clone_args *)arg1)->stack != 0) { // clone3
         void *ret_addr = get_syscall_return_address(wrapper_sp);
-        syscall_rtn = clone3_syscall(arg1, arg2, arg3, 0, arg5, ret_addr);
+        syscall_rtn = clone3_syscall(arg1, arg2, arg3, 0, arg5, ret_addr, NULL);
       } else if (sc_no == SYS_vfork ||
                  (sc_no == SYS_clone &&
                   (arg1 & (CLONE_VM | CLONE_VFORK | SIGCHLD)) ==


### PR DESCRIPTION
This PR modifies `clone_syscall` and `clone3_syscall` signatures to accept context argument (one `void *`). This context argument can then be accessed from the post clone hook.

The implementation uses `xmm0` as a vehicle to pass the context argument to the child. The assumption is that it's unlikely libc `clone()` wrappers or other `clone()` users will depend on the value of `xmm0` in the child thread. `xmm0` value is set to NaN (ff bit pattern) after `post_clone_hook` exits, which should allow us to catch some instances of that not being the case.

Parent can use `xmm0` freely, as we save its value on `clone_syscall` /`clone3_syscall` function entry.

Note that this PR does not make SaBRe any less stable. For example, if the client depends on the `rbx` value in the child, it will get corrupted, as exit path for `clone_syscall` bypasses normal register restore procedure, so the assumption that the child will just call the callback and do nothing else is already there.