### PR TITLE
Avoid treating linker executables as the dynamic loader

### DIFF
--- a/loader/rewriter.c
+++ b/loader/rewriter.c
@@ -471,6 +471,18 @@ bool starts_with(const char *a, const char *b) {
 static bool lib_name_match(const char *bare, const char *pathname) {
   const char *real = strip_pathname(pathname);
 
+  // The dynamic loader intercept uses the historical bare name "ld". Do not
+  // confuse linker executables such as ld, ld.bfd, or ld-new with the
+  // ld-linux/ld.so loader family.
+  if (!strcmp(bare, "ld")) {
+    const char *so = strstr(real, ".so");
+    const bool has_so_boundary =
+        so != NULL && (so[3] == '\0' || so[3] == '.');
+    return has_so_boundary &&
+           (starts_with(real, "ld-linux-") || starts_with(real, "ld.so") ||
+            (starts_with(real, "ld-") && real[3] >= '0' && real[3] <= '9'));
+  }
+
   if (starts_with(real, bare)) {
     return true;
   }

--- a/tests/regression/test_ld_name.c
+++ b/tests/regression/test_ld_name.c
@@ -20,13 +20,23 @@
 
 static long raw_write(void) {
   static const char msg[] = "ordinary ld client\n";
+#if defined(__x86_64__)
   long result;
-
   __asm__ volatile("syscall"
                    : "=a"(result)
                    : "a"(1), "D"(1), "S"(msg), "d"(sizeof(msg) - 1)
                    : "rcx", "r11", "memory");
   return result;
+#elif defined(__riscv)
+  register long a0 __asm__("a0") = 1;
+  register const char *a1 __asm__("a1") = msg;
+  register size_t a2 __asm__("a2") = sizeof(msg) - 1;
+  register long a7 __asm__("a7") = 64;
+  __asm__ volatile("ecall" : "+r"(a0) : "r"(a1), "r"(a2), "r"(a7) : "memory");
+  return a0;
+#else
+#error "unsupported architecture"
+#endif
 }
 
 int main(void) { return raw_write() < 0; }

--- a/tests/regression/test_ld_name.c
+++ b/tests/regression/test_ld_name.c
@@ -1,0 +1,32 @@
+/*  Copyright © 2019 Software Reliability Group, Imperial College London
+ *
+ *  This file is part of SaBRe.
+ *
+ *  SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/*
+ * RUN: rm -rf %t1.dir %t1.actual
+ * RUN: mkdir -p %t1.dir
+ * RUN: %{cc} %s -o %t1.dir/client
+ * RUN: for name in ld ld.bfd ld.gold ld.lld ld-new ld-linux-tool ld-new.so-helper ld.software; do cp %t1.dir/client %t1.dir/$name && %{sbr} %{sbr-id} -- %t1.dir/$name >> %t1.actual || exit $?; done
+ * RUN: printf "ordinary ld client\nordinary ld client\nordinary ld client\nordinary ld client\nordinary ld client\nordinary ld client\nordinary ld client\nordinary ld client\n" > %t1.expected
+ * RUN: diff %t1.actual %t1.expected
+ * RUN: %{sbr} %{sbr-trc} -- %t1.dir/ld-new > /dev/null 2> %t1.trace
+ * RUN: grep 'write(1' %t1.trace
+ */
+
+#include <stddef.h>
+
+static long raw_write(void) {
+  static const char msg[] = "ordinary ld client\n";
+  long result;
+
+  __asm__ volatile("syscall"
+                   : "=a"(result)
+                   : "a"(1), "D"(1), "S"(msg), "d"(sizeof(msg) - 1)
+                   : "rcx", "r11", "memory");
+  return result;
+}
+
+int main(void) { return raw_write() < 0; }


### PR DESCRIPTION
[impl agent, gpt-5.6-sol]

## Summary
- restrict the historical bare `ld` hook to glibc dynamic-loader-shaped basenames with a `.so` boundary
- stop ordinary linker executables (`ld`, `ld.bfd`, `ld.gold`, `ld.lld`, `ld-new`) from entering dynamic-loader premain handling
- add a raw-syscall regression for x86-64 and RISC-V, including adversarial prefix collisions

## Validation
- `lit -v --timeout 30 --filter test_ld_name build-default/tests`: 1/1 passed
- full SaBRe suite: 70 passed, 3 unsupported, 3 baseline-equivalent host failures (`dumpkeys.sh`, `fgconsole.sh`, `test_sigill.S`)
- Hermit SaBRe strict/verify gate: 147/147 passed with this loader at Hermit `7ceec9d5263fb8e0af975f1099d098178db54510`
- `clang-format --dry-run --Werror tests/regression/test_ld_name.c`: passed
- two independent adversarial reviews: no blockers